### PR TITLE
Add ability to perform basic volume actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project is not ready for production usage, use at your own risk.
 - `/linode/instances/$id/shutdown`
   - [x] `POST`
 - `/linode/instances/$id/volumes`
-  - [ ] `GET`
+  - [X] `GET`
 
 ### Backups
 
@@ -312,15 +312,17 @@ This project is not ready for production usage, use at your own risk.
 ## Volumes
 
 - `/volumes`
-  - [ ] `GET`
+  - [X] `GET`
   - [ ] `POST`
 - `/volumes/$id`
-  - [ ] `GET`
+  - [X] `GET`
   - [ ] `POST`
   - [ ] `DELETE`
 - `/volumes/$id/attach`
-  - [ ] `POST`
+  - [X] `POST`
 - `/volumes/$id/clone`
-  - [ ] `POST`
+  - [X] `POST`
 - `/volumes/$id/detach`
-  - [ ] `POST`
+  - [X] `POST`
+- `/volumes/$id/resize`
+  - [X] `POST`

--- a/client.go
+++ b/client.go
@@ -34,6 +34,7 @@ type Client struct {
 	Instances    *Resource
 	Regions      *Resource
 	StackScripts *Resource
+	Volumes      *Resource
 }
 
 // R wraps resty's R method
@@ -81,6 +82,7 @@ func NewClient(codeAPIKey *string, transport http.RoundTripper) (*Client, error)
 		instancesName:    NewResource(instancesName, instancesEndpoint, false),
 		regionsName:      NewResource(regionsName, regionsEndpoint, false),
 		backupsName:      NewResource(backupsName, backupsEndpoint, true),
+		volumesName:      NewResource(volumesName, volumesEndpoint, false),
 	}
 
 	return &Client{
@@ -93,5 +95,6 @@ func NewClient(codeAPIKey *string, transport http.RoundTripper) (*Client, error)
 		Instances:    resources[instancesName],
 		Regions:      resources[regionsName],
 		Backups:      resources[backupsName],
+		Volumes:      resources[volumesName],
 	}, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -69,4 +69,7 @@ func TestClientAliases(t *testing.T) {
 	if client.Regions == nil {
 		t.Error("Expected alias for Regions to return a *Resource")
 	}
+	if client.Volumes == nil {
+		t.Error("Expected alias for Volumes to return a *Resource")
+	}
 }

--- a/linodes.go
+++ b/linodes.go
@@ -235,6 +235,26 @@ func (c *Client) ShutdownInstance(id int) (bool, error) {
 	return settleBoolResponseOrError(c.R().Post(e))
 }
 
+// ListInstanceVolumes lists volumes attached to a linode instance
+func (c *Client) ListInstanceVolumes(id int) ([]*LinodeVolume, error) {
+	e, err := c.Instances.Endpoint()
+	e = fmt.Sprintf("%s/%d/volumes", e, id)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.R().
+		SetResult(&LinodeVolumesPagedResponse{}).
+		Get(e)
+	if err != nil {
+		return nil, err
+	}
+	l := resp.Result().(*LinodeVolumesPagedResponse).Data
+	for _, el := range l {
+		el.fixDates()
+	}
+	return l, nil
+}
+
 func settleBoolResponseOrError(resp *resty.Response, err error) (bool, error) {
 	if err != nil {
 		return false, err

--- a/resources.go
+++ b/resources.go
@@ -12,12 +12,14 @@ const (
 	instancesName    = "instances"
 	regionsName      = "regions"
 	backupsName      = "backups"
+	volumesName      = "volumes"
 
 	stackscriptsEndpoint = "linode/stackscripts"
 	imagesEndpoint       = "images"
 	instancesEndpoint    = "linode/instances"
 	regionsEndpoint      = "regions"
 	backupsEndpoint      = "linode/instances/{{ .ID }}/backups"
+	volumesEndpoint      = "volumes"
 )
 
 // Resource represents a linode API resource

--- a/volumes.go
+++ b/volumes.go
@@ -1,0 +1,159 @@
+package golinode
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// LinodeImagesPagedResponse represents a linode API response for listing of images
+type LinodeVolumesPagedResponse struct {
+	Page, Pages, Results int
+	Data                 []*LinodeVolume
+}
+
+func (l *LinodeVolume) fixDates() *LinodeVolume {
+	l.Created, _ = parseDates(l.CreatedStr)
+	l.Updated, _ = parseDates(l.UpdatedStr)
+	return l
+}
+
+// LinodeVolume represents a linode volume object
+type LinodeVolume struct {
+	CreatedStr string `json:"created"`
+	UpdatedStr string `json:"updated"`
+
+	ID       int
+	Label    string
+	Status   string
+	Region   string
+	Size     int
+	LinodeID int        `json:"linode_id"`
+	Created  *time.Time `json:"-"`
+	Updated  *time.Time `json:"-"`
+}
+
+type LinodeVolumeAttachOptions struct {
+	LinodeID int
+	ConfigID int
+}
+
+// ListVolumes will list linode volumes
+func (c *Client) ListVolumes() ([]*LinodeVolume, error) {
+	e, err := c.Volumes.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.R().
+		SetResult(&LinodeVolumesPagedResponse{}).
+		Get(e)
+	if err != nil {
+		return nil, err
+	}
+	list := resp.Result().(*LinodeVolumesPagedResponse).Data
+	for _, el := range list {
+		el.fixDates()
+	}
+	return list, nil
+}
+
+// GetInstance gets the instance with the provided ID
+func (c *Client) GetVolume(volumeID int) (*LinodeVolume, error) {
+	e, err := c.Volumes.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	e = fmt.Sprintf("%s/%d", e, volumeID)
+	resp, err := c.R().
+		SetResult(&LinodeVolume{}).
+		Get(e)
+	if err != nil {
+		return nil, err
+	}
+	i := resp.Result().(*LinodeVolume).fixDates()
+	return i, nil
+}
+
+// BootInstance will boot a new linode instance
+func (c *Client) AttachVolume(id int, options *LinodeVolumeAttachOptions) (bool, error) {
+	body := ""
+	if bodyData, err := json.Marshal(options); err == nil {
+		body = string(bodyData)
+	} else {
+		return false, err
+	}
+
+	e, err := c.Volumes.Endpoint()
+	if err != nil {
+		return false, err
+	}
+
+	e = fmt.Sprintf("%s/%d/attach", e, id)
+	resp, err := c.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		Post(e)
+
+	return settleBoolResponseOrError(resp, err)
+}
+
+// CloneInstance clones a Linode instance
+func (c *Client) CloneVolume(id int, label string) (*LinodeVolume, error) {
+	body := fmt.Sprintf("{\"label\":\"%d\"}", label)
+
+	e, err := c.Volumes.Endpoint()
+	if err != nil {
+		return nil, err
+	}
+	e = fmt.Sprintf("%s/%d/clone", e, id)
+
+	req := c.R().SetResult(&LinodeVolume{})
+
+	resp, err := req.
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		Post(e)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Result().(*LinodeVolume).fixDates(), nil
+}
+
+// DetachVolume detaches a Linode instance
+func (c *Client) DetachVolume(id int) (bool, error) {
+	body := ""
+
+	e, err := c.Volumes.Endpoint()
+	if err != nil {
+		return false, err
+	}
+
+	e = fmt.Sprintf("%s/%d/detach", e, id)
+
+	resp, err := c.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		Post(e)
+
+	return settleBoolResponseOrError(resp, err)
+}
+
+// ResizeInstance resizes an instance to new Linode type
+func (c *Client) ResizeVolume(id int, size int) (bool, error) {
+	body := fmt.Sprintf("{\"size\":\"%d\"}", size)
+
+	e, err := c.Volumes.Endpoint()
+	if err != nil {
+		return false, err
+	}
+	e = fmt.Sprintf("%s/%d/resize", e, id)
+
+	resp, err := c.R().
+		SetHeader("Content-Type", "application/json").
+		SetBody(body).
+		Post(e)
+
+	return settleBoolResponseOrError(resp, err)
+}

--- a/volumes_test.go
+++ b/volumes_test.go
@@ -1,0 +1,32 @@
+package golinode
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestListVolumes(t *testing.T) {
+	client, err := createTestClient(debugAPI)
+	if err != nil {
+		t.Errorf("Error creating test client %v", err)
+	}
+	volumes, err := client.ListVolumes()
+	if err != nil {
+		t.Errorf("Error listing instances, expected struct, got error %v", err)
+	}
+	if len(volumes) != 1 {
+		t.Errorf("Expected a list of instances, but got %v", volumes)
+	}
+}
+
+func TestGetVolume(t *testing.T) {
+	client, err := createTestClient(debugAPI)
+	if err != nil {
+		t.Errorf("Error creating test client %v", err)
+	}
+	linode, err := client.GetVolume(4090913)
+	if err != nil {
+		t.Errorf("Error getting instance 1234, expected *LinodeVolume, got error %v", err)
+	}
+	fmt.Printf("%#v \n", linode)
+}


### PR DESCRIPTION
I was just taking a peak at this repo and figured I'd try adding something to get a feel for it.

I don't know how to get the test/vcr data captured, but I'm sure you will need that updated for volumes.

I think you may have some things in the fixtures related to custom stack scripts that you may not want in this repo publicly (certs maybe?).

I think it may end up being strange [to have some functions take an "options" arguments](https://github.com/chiefy/go-linode/pull/2/files#diff-8c844552c440c1a179655f8ba2f81d11R78) (to only define two options) when other functions just accept each scalar value as an argument.