### PR TITLE
initial pass at pagination (Kernels, Linodes)

### DIFF
--- a/API_SUPPORT.md
+++ b/API_SUPPORT.md
@@ -4,7 +4,7 @@
 
 - `/linode/instances`
   - [x] `GET`
-  - [ ] `POST`
+  - [X] `POST`
 - `/linode/instances/$id`
   - [x] `GET`
   - [ ] `PUT`

--- a/client.go
+++ b/client.go
@@ -1,7 +1,6 @@
 package golinode
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -83,8 +82,9 @@ func NewClient(codeAPIKey *string, transport http.RoundTripper) (*Client, error)
 	} else if envAPIKey, ok := os.LookupEnv(APIEnvVar); ok {
 		linodeAPIKey = envAPIKey
 	}
+
 	if len(linodeAPIKey) == 0 || linodeAPIKey == "" {
-		return nil, errors.New("No API key was provided or LINODE_API_KEY was not set")
+		log.Print("Could not find LINODE_API_KEY, authenticated endpoints will fail.")
 	}
 
 	restyClient := resty.New().

--- a/client.go
+++ b/client.go
@@ -61,6 +61,13 @@ func (c Client) Resource(resourceName string) *Resource {
 	return selectedResource
 }
 
+// ListOptions are the pagination parameters for List endpoints
+type ListOptions struct {
+	Page    int `url:"page,omitempty"`
+	PerPage int `url:"per_page,omitempty"`
+	Results int `url:"results,omitempty"`
+}
+
 // NewClient factory to create new Client struct
 func NewClient(codeAPIKey *string, transport http.RoundTripper) (*Client, error) {
 	linodeAPIKey := ""

--- a/client.go
+++ b/client.go
@@ -61,11 +61,17 @@ func (c Client) Resource(resourceName string) *Resource {
 	return selectedResource
 }
 
-// ListOptions are the pagination parameters for List endpoints
-type ListOptions struct {
+// PageOptions are the pagination parameters for List endpoints
+type PageOptions struct {
 	Page    int `url:"page,omitempty"`
-	PerPage int `url:"per_page,omitempty"`
+	Pages   int `url:"per_page,omitempty"`
 	Results int `url:"results,omitempty"`
+}
+
+// ListOptions are the pagination and filtering (TODO) parameters for endpoints
+type ListOptions struct {
+	*PageOptions
+	Filter string
 }
 
 // NewClient factory to create new Client struct

--- a/example/main.go
+++ b/example/main.go
@@ -9,11 +9,8 @@ import (
 )
 
 func main() {
-	apiKey, ok := os.LookupEnv("LINODE_API_KEY")
-	if !ok {
-		log.Fatal("Could not find LINODE_API_KEY, please assert it is set.")
-	}
-	linodeClient, err := golinode.NewClient(&apiKey, nil)
+	// Demonstrate endpoints that don't require an account or token
+	linodeClient, err := golinode.NewClient(nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -30,6 +27,18 @@ func main() {
 		log.Fatal(err)
 	}
 	fmt.Printf("%+v", kernels)
+
+	apiKey, ok := os.LookupEnv("LINODE_API_KEY")
+	if !ok {
+		log.Fatal("Could not find LINODE_API_KEY, please assert it is set.")
+	}
+
+	// Demonstrate endpoints that require an access token
+	linodeClient, err = golinode.NewClient(&apiKey, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	linodeClient.SetDebug(true)
 
 	linodes, err := linodeClient.ListInstances(nil)
 

--- a/example/main.go
+++ b/example/main.go
@@ -25,13 +25,13 @@ func main() {
 	}
 	fmt.Printf("%+v", types)
 
-	kernels, err := linodeClient.ListKernels()
+	kernels, err := linodeClient.ListKernels(nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Printf("%+v", kernels)
 
-	linodes, err := linodeClient.ListInstances()
+	linodes, err := linodeClient.ListInstances(nil)
 
 	if len(linodes) == 0 {
 		log.Printf("No Linodes to inspect.")

--- a/example/main.go
+++ b/example/main.go
@@ -9,6 +9,10 @@ import (
 )
 
 func main() {
+	// Trigger endpoints that accrue a balance
+	apiKey, apiOk := os.LookupEnv("LINODE_API_KEY")
+	var SpendMoney = true && apiOk
+
 	// Demonstrate endpoints that don't require an account or token
 	linodeClient, err := golinode.NewClient(nil, nil)
 	if err != nil {
@@ -28,9 +32,9 @@ func main() {
 	}
 	fmt.Printf("%+v", kernels)
 
-	apiKey, ok := os.LookupEnv("LINODE_API_KEY")
-	if !ok {
+	if !apiOk || len(apiKey) == 0 {
 		log.Fatal("Could not find LINODE_API_KEY, please assert it is set.")
+		os.Exit(1)
 	}
 
 	// Demonstrate endpoints that require an access token
@@ -40,13 +44,23 @@ func main() {
 	}
 	linodeClient.SetDebug(true)
 
+	var linode *golinode.LinodeInstance
+
+	if SpendMoney {
+		linode, err = linodeClient.CreateInstance(&golinode.InstanceCreateOptions{Region: "us-central", Type: "g5-nanode-1"})
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%#v", linode)
+	}
+
 	linodes, err := linodeClient.ListInstances(nil)
 
 	if len(linodes) == 0 {
 		log.Printf("No Linodes to inspect.")
 	} else {
 		// This is redundantly used for illustrative purposes
-		linode, err := linodeClient.GetInstance(linodes[0].ID)
+		linode, err = linodeClient.GetInstance(linodes[0].ID)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/images.go
+++ b/images.go
@@ -6,8 +6,8 @@ import (
 
 // LinodeImagesPagedResponse represents a linode API response for listing of images
 type LinodeImagesPagedResponse struct {
-	Page, Pages, Results int
-	Data                 []*LinodeImage
+	*PageOptions
+	Data []*LinodeImage
 }
 
 // LinodeImage represents a linode image object

--- a/instances.go
+++ b/instances.go
@@ -71,18 +71,18 @@ type LinodeInstance struct {
 
 // InstanceCreateOptions require only Region and Type
 type InstanceCreateOptions struct {
-	Region          string            `json:"region,omitempty"`
-	Type            string            `json:"type,omitempty"`
-	Label           string            `json:",omitempty"`
-	Group           string            `json:",omitempty"`
+	Region          string            `json:"region"`
+	Type            string            `json:"type"`
+	Label           string            `json:"label,omitempty"`
+	Group           string            `json:"group,omitempty"`
 	RootPass        string            `json:"root_pass,omitempty"`
 	AuthorizedKeys  []string          `json:"authorized_keys,omitempty"`
 	StackScriptID   int               `json:"stackscript_id,omitempty"`
 	StackScriptData map[string]string `json:"stackscript_data,omitempty"`
 	BackupID        int               `json:"backup_id,omitempty"`
-	Image           string            `json:",omitempty"`
+	Image           string            `json:"image,omitempty"`
 	BackupsEnabled  bool              `json:"backups_enabled,omitempty"`
-	Booted          bool              `json:",omitempty"`
+	Booted          bool              `json:"booted,omitempty"`
 }
 
 func (l *LinodeInstance) fixDates() *LinodeInstance {

--- a/instances.go
+++ b/instances.go
@@ -126,20 +126,20 @@ func (l *LinodeInstanceConfig) fixDates() *LinodeInstanceConfig {
 
 // LinodeInstancesPagedResponse represents a linode API response for listing
 type LinodeInstancesPagedResponse struct {
-	Page, Pages, Results int
-	Data                 []*LinodeInstance
+	*PageOptions
+	Data []*LinodeInstance
 }
 
 // LinodeInstanceDisksPagedResponse represents a linode API response for listing
 type LinodeInstanceDisksPagedResponse struct {
-	Page, Pages, Results int
-	Data                 []*LinodeInstanceDisk
+	*PageOptions
+	Data []*LinodeInstanceDisk
 }
 
 // LinodeInstanceConfigsPagedResponse represents a linode API response for listing
 type LinodeInstanceConfigsPagedResponse struct {
-	Page, Pages, Results int
-	Data                 []*LinodeInstanceConfig
+	*PageOptions
+	Data []*LinodeInstanceConfig
 }
 
 // ListInstances lists linode instances
@@ -152,8 +152,7 @@ func (c *Client) ListInstances(opts *ListOptions) ([]*LinodeInstance, error) {
 	req := c.R().SetResult(&LinodeInstancesPagedResponse{})
 
 	if opts != nil {
-		req.SetQueryParam("page", strconv.Itoa(opts.Page)).
-			SetQueryParam("per_page", strconv.Itoa(opts.PerPage))
+		req.SetQueryParam("page", strconv.Itoa(opts.Page))
 	}
 
 	r, err := req.Get(e)
@@ -171,7 +170,7 @@ func (c *Client) ListInstances(opts *ListOptions) ([]*LinodeInstance, error) {
 
 	if opts == nil {
 		for page := 2; page <= pages; page = page + 1 {
-			next, _ := c.ListInstances(&ListOptions{Page: page})
+			next, _ := c.ListInstances(&ListOptions{PageOptions: &PageOptions{Page: 1}})
 			data = append(data, next...)
 		}
 	} else {

--- a/instances.go
+++ b/instances.go
@@ -170,7 +170,7 @@ func (c *Client) ListInstances(opts *ListOptions) ([]*LinodeInstance, error) {
 
 	if opts == nil {
 		for page := 2; page <= pages; page = page + 1 {
-			next, _ := c.ListInstances(&ListOptions{PageOptions: &PageOptions{Page: 1}})
+			next, _ := c.ListInstances(&ListOptions{PageOptions: &PageOptions{Page: page}})
 			data = append(data, next...)
 		}
 	} else {

--- a/instances_test.go
+++ b/instances_test.go
@@ -11,7 +11,7 @@ func TestListInstances(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error creating test client %v", err)
 	}
-	linodes, err := client.ListInstances()
+	linodes, err := client.ListInstances(nil)
 	if err != nil {
 		t.Errorf("Error listing instances, expected struct, got error %v", err)
 	}

--- a/linodes.go
+++ b/linodes.go
@@ -52,14 +52,14 @@ type LinodeType struct {
 
 // LinodeKernelsPagedResponse represents a linode kernels API response for listing
 type LinodeKernelsPagedResponse struct {
-	Page, Pages, Results int
-	Data                 []*LinodeKernel
+	*PageOptions
+	Data []*LinodeKernel
 }
 
 // LinodeTypesPagedResponse represents a linode types API response for listing
 type LinodeTypesPagedResponse struct {
-	Page, Pages, Results int
-	Data                 []*LinodeType
+	*PageOptions
+	Data []*LinodeType
 }
 
 // LinodeCloneOptions is an options struct when sending a clone request to the API
@@ -83,8 +83,7 @@ func (c *Client) ListKernels(opts *ListOptions) ([]*LinodeKernel, error) {
 	req := c.R().SetResult(&LinodeKernelsPagedResponse{})
 
 	if opts != nil {
-		req.SetQueryParam("page", strconv.Itoa(opts.Page)).
-			SetQueryParam("per_page", strconv.Itoa(opts.PerPage))
+		req.SetQueryParam("page", strconv.Itoa(opts.Page))
 	}
 
 	r, err := req.Get(e)
@@ -98,7 +97,7 @@ func (c *Client) ListKernels(opts *ListOptions) ([]*LinodeKernel, error) {
 
 	if opts == nil {
 		for page := 2; page <= pages; page = page + 1 {
-			next, _ := c.ListKernels(&ListOptions{Page: page})
+			next, _ := c.ListKernels(&ListOptions{PageOptions: &PageOptions{Page: page}})
 			data = append(data, next...)
 		}
 	} else {

--- a/linodes.go
+++ b/linodes.go
@@ -2,6 +2,7 @@ package golinode
 
 import (
 	"fmt"
+	"strconv"
 )
 
 /*
@@ -74,19 +75,37 @@ type LinodeCloneOptions struct {
 }
 
 // ListKernels lists linode kernels
-func (c *Client) ListKernels() ([]*LinodeKernel, error) {
+func (c *Client) ListKernels(opts *ListOptions) ([]*LinodeKernel, error) {
 	e, err := c.Kernels.Endpoint()
 	if err != nil {
 		return nil, err
 	}
-	r, err := c.R().
-		SetResult(&LinodeKernelsPagedResponse{}).
-		Get(e)
+	req := c.R().SetResult(&LinodeKernelsPagedResponse{})
+
+	if opts != nil {
+		req.SetQueryParam("page", strconv.Itoa(opts.Page)).
+			SetQueryParam("per_page", strconv.Itoa(opts.PerPage))
+	}
+
+	r, err := req.Get(e)
 	if err != nil {
 		return nil, err
 	}
-	l := r.Result().(*LinodeKernelsPagedResponse).Data
-	return l, nil
+
+	data := r.Result().(*LinodeKernelsPagedResponse).Data
+	pages := r.Result().(*LinodeKernelsPagedResponse).Pages
+	results := r.Result().(*LinodeKernelsPagedResponse).Results
+
+	if opts == nil {
+		for page := 2; page <= pages; page = page + 1 {
+			next, _ := c.ListKernels(&ListOptions{Page: page})
+			data = append(data, next...)
+		}
+	} else {
+		opts.Results = results
+	}
+
+	return data, nil
 }
 
 // ListTypes lists linode types

--- a/linodes.go
+++ b/linodes.go
@@ -102,6 +102,7 @@ func (c *Client) ListKernels(opts *ListOptions) ([]*LinodeKernel, error) {
 		}
 	} else {
 		opts.Results = results
+		opts.Pages = pages
 	}
 
 	return data, nil

--- a/regions.go
+++ b/regions.go
@@ -2,8 +2,8 @@ package golinode
 
 // LinodeRegionsPagedResponse represents a linode API response for listing
 type LinodeRegionsPagedResponse struct {
-	Page, Pages, Results int
-	Data                 []*LinodeRegion
+	*PageOptions
+	Data []*LinodeRegion
 }
 
 // LinodeRegion represents a linode region object

--- a/resources.go
+++ b/resources.go
@@ -68,7 +68,7 @@ func (r Resource) EndpointWithID(id int) (string, error) {
 	return r.render(id)
 }
 
-// Endpoint will return the non-templated endpoint strig for resource
+// Endpoint will return the non-templated endpoint string for resource
 func (r Resource) Endpoint() (string, error) {
 	if r.isTemplate {
 		return "", fmt.Errorf("Tried to get endpoint for %s without providing data for template", r.name)

--- a/stackscripts.go
+++ b/stackscripts.go
@@ -7,8 +7,8 @@ import (
 
 // LinodeStackscriptsPagedResponse represents a linode API response for listing
 type LinodeStackscriptsPagedResponse struct {
-	Page, Pages, Results int
-	Data                 []*LinodeStackscript
+	*PageOptions
+	Data []*LinodeStackscript
 }
 
 // LinodeStackscript represents a linode stack script

--- a/test/main.go
+++ b/test/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 	log.Println("Succesfully got linode regions")
 
-	_, err = c.ListInstances()
+	_, err = c.ListInstances(nil)
 	if err != nil {
 		log.Fatalf("Failed to get linode instances: %s", err)
 	}

--- a/volumes.go
+++ b/volumes.go
@@ -8,8 +8,8 @@ import (
 
 // LinodeVolumesPagedResponse represents a linode API response for listing of volumes
 type LinodeVolumesPagedResponse struct {
-	Page, Pages, Results int
-	Data                 []*LinodeVolume
+	*PageOptions
+	Data []*LinodeVolume
 }
 
 func (l *LinodeVolume) fixDates() *LinodeVolume {


### PR DESCRIPTION
A workable approach to pagination (#5).  (I also included an initial CreateInstance, but can move that to another PR)

There is room to simplify this through interfaces.  This PR is mostly intended for discussion.

If a `ListSomething` endpoint is given a `nil` `ListOption` it will automatically paginate and return all results (error handling is still needed for the subsequent requests).

If a `ListSomething` endpoint is given a `ListOption`, it will fetch the requested page and populate the `Results` response from the server.

You can see that this is finding all of the Linode Kernels:
```
$ ./example  2>&1 | grep version | wc -l
     218
``` 